### PR TITLE
Make comment button bigger, but invisible

### DIFF
--- a/src/css/modules/_comments.scss
+++ b/src/css/modules/_comments.scss
@@ -14,7 +14,7 @@
     opacity: 0;
     padding: 0.75rem $spacing-small;
     text-align: center;
-    transform: scale(0);
+    transform: scale(0.7);
     transition: $transition-base;
   }
 


### PR DESCRIPTION
When it scaled to 0 it made the animation a bit jarring. It also made
the comment button harder to click because it would be completely
unclickable. Now it is still there, but invisible, making it so you have
a bit more time to move your mouse to the icon before it disappears. You
can also move your mouse straight to where the comment icon would be
without hovering over the paragraph first.